### PR TITLE
tsconfig: add types: [node] for TS 6 compatibility

### DIFF
--- a/project/.sdk/tm/ts/src/tsconfig.json
+++ b/project/.sdk/tm/ts/src/tsconfig.json
@@ -9,6 +9,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2022",
+    "types": ["node"],
     "declaration": true,
     "declarationDir": "../dist"
   }

--- a/project/.sdk/tm/ts/test/tsconfig.json
+++ b/project/.sdk/tm/ts/test/tsconfig.json
@@ -8,6 +8,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2022"
+    "target": "ES2022",
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
## Summary
- Generated SDKs fail to compile under TypeScript 6 because `@types/node` is no longer auto-included with `module: "nodenext"`.
- Adds `"types": ["node"]` to both the `src` and `test` tsconfig templates so the generated SDK compiles cleanly on TS 6 (and remains a no-op on TS 5).

## Background
With TypeScript 6.0.x and `module: "nodenext"`, the implicit inclusion of all `@types/*` packages tightened up. Without an explicit `types` entry, generated SDKs hit:

```
src/<Sdk>EntityBase.ts(2,25):           TS2591  Cannot find name 'node:util'
src/<Sdk>SDK.ts(5,25):                  TS2591  Cannot find name 'node:util'
src/Context.ts(2,25):                   TS2591  Cannot find name 'node:util'
src/utility/MakeOptionsUtility.ts(70,48):  TS2304  Cannot find name 'global'
```

Reproduced against an SDK generated for the `aareguru` API — adding `"types": ["node"]` makes `tsc --build src` exit clean (4 errors → 0) and the test build/runner pass 118/118.

## Test plan
- [x] Reproduce failure on TS 6.0.3 with current templates
- [x] Verify `tsc --build src` passes after the change
- [x] Verify `tsc -p test/tsconfig.json` passes after the change
- [x] Verify generated SDK tests still run (118/118 passing for `aareguru`)